### PR TITLE
feat: in-page issue form and update prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,11 @@ Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) and ad
 ## Notifications
 Watch this repository to receive email updates for new issues. A sample GitHub Action (`issue-alert.yml`) is included to send custom email notifications when issues are opened. Configure the required secrets (`MAIL_USERNAME`, `MAIL_PASSWORD`, `ISSUE_ALERT_EMAIL`) in your repository settings to enable it.
 
+## Issue Reporting from the App
+The guide includes a built-in form for creating GitHub issues without leaving the page. When submitting, provide a GitHub personal access token when prompted. The token is stored locally in your browser for future use.
+
+## Offline Use and Updates
+A service worker caches core files so the guide works offline and keeps your progress between updates. When a new version is available, a prompt will appear with an Update button to reload the latest content.
+
 ## License
 Distributed under the MIT License. See [LICENSE](LICENSE) for more information.

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -8,6 +8,12 @@ module.exports = [
       globals: {
         document: "readonly",
         localStorage: "readonly",
+        alert: "readonly",
+        fetch: "readonly",
+        navigator: "readonly",
+        window: "readonly",
+        self: "readonly",
+        caches: "readonly",
       }
     },
     rules: {

--- a/index.html
+++ b/index.html
@@ -8,6 +8,10 @@
     <link rel="stylesheet" href="style.css">
     </head>
 <body>
+    <div id="update-banner" class="update-banner">
+        <span>New version available</span>
+        <button id="reload-btn" class="btn btn-primary">Update</button>
+    </div>
     <div class="container">
         <!-- Header -->
         <header class="header">
@@ -91,7 +95,17 @@
     </div>
 </div>
 
-    <footer style="text-align:center; padding:1rem;">Have an idea or found a bug? <a href="https://github.com/hendrism/ai-guide/issues">Open an issue</a>.</footer>
+    <footer style="text-align:center; padding:1rem;">Have an idea or found a bug? <button id="issue-btn" class="link-button">Open an issue</button>. <button id="ideas-btn" class="link-button">Need more ideas?</button></footer>
+    <div id="issue-modal" class="modal hidden">
+        <div class="modal-content">
+            <span id="close-issue-modal" class="close">&times;</span>
+            <h3>Submit an Issue</h3>
+            <input type="text" id="issue-title" placeholder="Title" />
+            <textarea id="issue-body" placeholder="Describe your issue"></textarea>
+            <input type="password" id="issue-token" placeholder="GitHub Token" />
+            <button id="submit-issue" class="btn btn-primary">Submit</button>
+        </div>
+    </div>
     <script src="journey-data.js"></script>
     <script src="main.js"></script>
 </body>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,39 @@
+const CACHE_NAME = 'ai-guide-cache-v1';
+const URLS_TO_CACHE = [
+  '/',
+  '/index.html',
+  '/style.css',
+  '/main.js',
+  '/journey-data.js'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.map(key => {
+        if (key !== CACHE_NAME) {
+          return caches.delete(key);
+        }
+      })
+    ))
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});
+
+self.addEventListener('message', event => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});

--- a/style.css
+++ b/style.css
@@ -307,7 +307,62 @@ background-color: #f9fafb;
 }
 
 .goal-option input[type="radio"] {
-margin: 0;
+    margin: 0;
+}
+
+.modal {
+position: fixed;
+z-index: 1000;
+left: 0;
+top: 0;
+width: 100%;
+height: 100%;
+background: rgba(0,0,0,0.5);
+display: flex;
+align-items: center;
+justify-content: center;
+}
+
+.modal-content {
+background: white;
+padding: 1rem;
+border-radius: 8px;
+width: 90%;
+max-width: 400px;
+}
+
+.modal .close {
+float: right;
+font-size: 1.25rem;
+cursor: pointer;
+}
+
+.hidden {
+display: none;
+}
+
+.link-button {
+background: none;
+border: none;
+color: #2563eb;
+text-decoration: underline;
+cursor: pointer;
+font: inherit;
+padding: 0;
+}
+
+.update-banner {
+position: fixed;
+bottom: 0;
+left: 0;
+right: 0;
+background-color: #2563eb;
+color: white;
+display: none;
+justify-content: space-between;
+align-items: center;
+padding: 0.5rem 1rem;
+z-index: 999;
 }
 
 .quick-reference {


### PR DESCRIPTION
## Summary
- open issue and idea requests in a modal form
- cache site assets with a service worker and show update prompts
- document how to submit issues from the app and work offline

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20030aa508320a44255acabd3c593