### PR TITLE
feat: personalize prompts and update theme

### DIFF
--- a/journey-data.js
+++ b/journey-data.js
@@ -60,7 +60,7 @@ const journeyData = [
         <div style="margin-bottom: 1.5rem;">
             <h3 style="font-weight: 600; margin-bottom: 0.75rem;">Step 2: Copy and paste this exact message:</h3>
             <div class="prompt-box">
-                "I'm new to AI. Can you explain in simple terms what you are and what you can help me with? Please give me 3 specific examples of how someone like me could use you."
+                "I'm new to AI, and my goal is {{userGoal}}. Can you explain in simple terms what you are and how you can help? Please give me 3 specific examples related to this goal."
             </div>
         </div>
 
@@ -133,9 +133,9 @@ const journeyData = [
     description: "Try 4 different types of tasks to see AI's strengths",
     tasks: [
         "Research Assistant: Ask about solar panels",
-        "Creative Brainstorming: Ask for hobby suggestions", 
+        "Creative Brainstorming: Ask for hobby suggestions",
         "Problem-Solving: Ask about computer troubleshooting",
-        "Learning Tutor: Ask about compound interest"
+        "Learning Tutor: Ask about {{userGoal}}"
     ],
     content: `
         <div class="content-grid" style="margin-bottom: 1.5rem;">
@@ -163,7 +163,7 @@ const journeyData = [
             <div class="content-card blue">
                 <h3 style="font-weight: 600; color: #1e40af; margin-bottom: 0.5rem;">Task 4: Learning Tutor</h3>
                 <div style="background: white; padding: 0.5rem; border-radius: 4px; font-size: 0.75rem; font-family: monospace;">
-                    "Explain how compound interest works. First explain it simply, then give me a concrete example with actual numbers."
+                    "I'm trying to learn more about {{userGoal}}. Can you break it down for a beginner and suggest one actionable first step?"
                 </div>
             </div>
         </div>

--- a/main.js
+++ b/main.js
@@ -57,10 +57,10 @@ journeyData.forEach((day, index) => {
 function updateDayContent() {
 const day = journeyData[currentDay];
 
-document.getElementById('day-title').textContent = 
-    (currentDay === 0 ? "Before You Start: " : `Day ${currentDay}: `) + day.title;
+document.getElementById('day-title').textContent =
+    (currentDay === 0 ? "Before You Start: " : `Day ${currentDay}: `) + applyUserSelections(day.title);
 document.getElementById('day-duration').textContent = `⏱️ ${day.duration}`;
-document.getElementById('day-description').textContent = day.description;
+document.getElementById('day-description').textContent = applyUserSelections(day.description);
 
 // Show/hide tasks section
 const tasksSection = document.getElementById('tasks-section');
@@ -72,7 +72,7 @@ if (day.tasks) {
 }
 
 // Update content
-document.getElementById('content-section').innerHTML = day.content;
+document.getElementById('content-section').innerHTML = applyUserSelections(day.content);
 
 // Re-attach event listeners for radio buttons
 setupContentEventListeners();
@@ -100,7 +100,7 @@ day.tasks.forEach((task, index) => {
     
     const text = document.createElement('span');
     text.className = 'task-text';
-    text.textContent = task;
+    text.textContent = applyUserSelections(task);
     if (isTaskCompleted(currentDay, index)) {
         text.classList.add('completed');
     }
@@ -154,6 +154,13 @@ if (userGoal && currentDay === 0) {
 } else {
     goalStatus.style.display = 'none';
 }
+
+}
+
+// Replace placeholders in content with user selections
+function applyUserSelections(str) {
+    if (!str) return '';
+    return str.replace(/{{userGoal}}/g, userGoal || 'your goal');
 }
 
 

--- a/style.css
+++ b/style.css
@@ -5,18 +5,18 @@
 }
 
 :root {
-    --md-sys-color-primary: #6750A4;
+    --md-sys-color-primary: #0d9488;
     --md-sys-color-on-primary: #FFFFFF;
-    --md-sys-color-primary-dark: #5B3E9E;
-    --md-sys-color-secondary: #625B71;
+    --md-sys-color-primary-dark: #0f766e;
+    --md-sys-color-secondary: #2563eb;
     --md-sys-color-on-secondary: #FFFFFF;
-    --md-sys-color-secondary-dark: #514667;
+    --md-sys-color-secondary-dark: #1e40af;
     --md-sys-color-background: #FFFBFE;
     --md-sys-color-on-background: #1C1B1F;
     --md-sys-color-surface: #FFFBFE;
     --md-sys-color-on-surface: #1C1B1F;
-    --md-sys-color-primary-container: #EADDFF;
-    --md-sys-color-on-primary-container: #21005D;
+    --md-sys-color-primary-container: #ccfbf1;
+    --md-sys-color-on-primary-container: #115e59;
     --md-sys-color-outline: #79747E;
     --md-sys-color-success-container: #E9F5EE;
     --md-sys-color-success: #22C55E;


### PR DESCRIPTION
## Summary
- Refresh site colors with a teal primary and blue secondary palette.
- Let the chosen goal influence tasks and prompts on later days.
- Add placeholder replacement logic for personalized content.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2436170248320bfbcb454160212f2